### PR TITLE
doc/FPGAs.yml: Fix yml structure in Intel Max 10

### DIFF
--- a/doc/FPGAs.yml
+++ b/doc/FPGAs.yml
@@ -136,7 +136,9 @@ Intel:
     Flash: OK
 
   - Description: Max 10
-    Model: 10M02, 10M08
+    Model: 
+      - 10M02
+      - 10M08
     URL: https://www.intel.fr/content/www/fr/fr/products/details/fpga/max/10.html
     Memory: SVF
     Flash: POF


### PR DESCRIPTION
`Model: 10M02, 10M08` is not correct YAML structure and parsing it generated `10m02,_10m08` model instead of `10m02` and `10m08` models.